### PR TITLE
fix: handle Pydantic V2 const in guardrails tool dropdown

### DIFF
--- a/api/v2/plugin_config_suggestions.py
+++ b/api/v2/plugin_config_suggestions.py
@@ -81,11 +81,18 @@ class AdminAPI(api_tools.APIModeHandler):  # pylint: disable=R0903
             items = sel.get("items", {})
             if isinstance(items, dict):
                 tools = items.get("enum", [])
+                # Pydantic V2 emits "const" instead of "enum" for single-value Literals
+                if not tools and "const" in items:
+                    tools = [items["const"]]
             #
-            # Fallback: check args_schemas keys in json_schema_extra
+            # Fallback: check args_schemas keys (may live directly on the
+            # property or nested under json_schema_extra depending on
+            # Pydantic version / toolkit implementation)
             if not tools:
-                extra = sel.get("json_schema_extra", {})
-                args_schemas = extra.get("args_schemas", {})
+                args_schemas = (
+                    sel.get("args_schemas")
+                    or sel.get("json_schema_extra", {}).get("args_schemas")
+                )
                 if isinstance(args_schemas, dict):
                     tools = list(args_schemas.keys())
             #


### PR DESCRIPTION
Pydantic V2 emits 'const' instead of 'enum' in JSON Schema for single-value Literal types. This caused toolkits with exactly one tool (e.g. data_analysis/pandas_analyze_data) to show an empty tool dropdown in Guardrails Sensitive Action Tools config.

Also fixed args_schemas fallback to check both top-level property and nested json_schema_extra paths.

Fixes: EL-3914